### PR TITLE
bugfix: fix read-only filesystem crash on Cloudron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,17 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 RUN npm install -g @anthropic-ai/claude-code aidevops
 
 # ============================================
+# Writable home directories (Cloudron read-only /app/code workaround)
+# /home/cloudron is in the read-only layer, so symlink writable paths
+# to /app/data (persistent) and /run (ephemeral) at build time.
+# ============================================
+RUN mkdir -p /app/data/.ssh /app/data/.config \
+    && rm -rf /home/cloudron/.ssh /home/cloudron/.config /home/cloudron/.gitconfig \
+    && ln -sfn /app/data/.ssh /home/cloudron/.ssh \
+    && ln -sfn /app/data/.config /home/cloudron/.config \
+    && ln -sfn /app/data/.gitconfig /home/cloudron/.gitconfig
+
+# ============================================
 # Application code
 # ============================================
 WORKDIR /app/code

--- a/start.sh
+++ b/start.sh
@@ -80,28 +80,26 @@ fi
 # ============================================
 # PHASE 4: SSH Configuration
 # ============================================
-# Configure SSH to use the persistent key
-mkdir -p /home/cloudron/.ssh
-if [[ -f /app/data/.ssh/id_ed25519 ]]; then
-	cp /app/data/.ssh/id_ed25519 /home/cloudron/.ssh/id_ed25519
-	cp /app/data/.ssh/id_ed25519.pub /home/cloudron/.ssh/id_ed25519.pub
-	chmod 600 /home/cloudron/.ssh/id_ed25519
-	chmod 644 /home/cloudron/.ssh/id_ed25519.pub
+# /home/cloudron/.ssh is a symlink to /app/data/.ssh (set up in Dockerfile)
+# Write directly to /app/data/.ssh — no copy needed
+chmod 600 /app/data/.ssh/id_ed25519 2>/dev/null || true
+chmod 644 /app/data/.ssh/id_ed25519.pub 2>/dev/null || true
 
-	# Pin GitHub SSH host key — replace any existing github.com entries to prevent
-	# poisoned keys from persisting. Avoids MITM risk from ssh-keyscan.
-	PINNED_GITHUB_KEY="github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
-	touch /home/cloudron/.ssh/known_hosts
-	grep -vE '^github\.com[ ,]' /home/cloudron/.ssh/known_hosts >/tmp/known_hosts.tmp || true
-	printf '%s\n' "$PINNED_GITHUB_KEY" >>/tmp/known_hosts.tmp
-	mv /tmp/known_hosts.tmp /home/cloudron/.ssh/known_hosts
-	chmod 644 /home/cloudron/.ssh/known_hosts
-fi
-chown -R cloudron:cloudron /home/cloudron/.ssh
+# Pin GitHub SSH host key — replace any existing github.com entries to prevent
+# poisoned keys from persisting. Avoids MITM risk from ssh-keyscan.
+PINNED_GITHUB_KEY="github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+touch /app/data/.ssh/known_hosts
+grep -vE '^github\.com[ ,]' /app/data/.ssh/known_hosts >/tmp/known_hosts.tmp || true
+printf '%s\n' "$PINNED_GITHUB_KEY" >>/tmp/known_hosts.tmp
+mv /tmp/known_hosts.tmp /app/data/.ssh/known_hosts
+chmod 644 /app/data/.ssh/known_hosts
 
 # ============================================
 # PHASE 5: Git Configuration
 # ============================================
+# /home/cloudron/.gitconfig is a symlink to /app/data/.gitconfig (set up in Dockerfile)
+touch /app/data/.gitconfig
+chown cloudron:cloudron /app/data/.gitconfig
 gosu cloudron:cloudron git config --global user.name "AI DevOps Worker"
 gosu cloudron:cloudron git config --global user.email "worker@aidevops.sh"
 gosu cloudron:cloudron git config --global init.defaultBranch main


### PR DESCRIPTION
## Summary

- Fix crash loop caused by `start.sh` trying to `mkdir` and `chown` inside read-only `/home/cloudron`
- Symlink `/home/cloudron/.ssh`, `.config`, and `.gitconfig` to writable `/app/data/` paths at Docker build time
- Write SSH keys and git config directly to `/app/data/` instead of copying to `/home/cloudron/`

## Root cause

Cloudron mounts `/app/code` (and by extension `/home/cloudron`) as read-only at runtime. The `set -eu` in `start.sh` caused immediate exit on the `chown` failure, so the Node.js server never started and the health check never passed.

## Files changed

- `Dockerfile` — add symlinks from `/home/cloudron/{.ssh,.config,.gitconfig}` to `/app/data/` paths
- `start.sh` — remove copy/mkdir/chown on `/home/cloudron/.ssh`, write directly to `/app/data/.ssh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container filesystem layout to improve persistence of configuration and data across restarts. SSH and Git configurations are now maintained through the container lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->