### PR TITLE
t013: Replace future date with generic placeholder in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Add the worker to your local `~/.config/aidevops/remote-hosts.json`:
       "address": "https://worker.my.example.com",
       "transport": "http",
       "auth_token": "YOUR_AUTH_TOKEN",
-      "added": "2026-03-02T00:00:00Z"
+      "added": "YYYY-MM-DDTHH:MM:SSZ"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded future date (`2026-03-02T00:00:00Z`) with generic `YYYY-MM-DDTHH:MM:SSZ` placeholder in the `remote-hosts.json` example config
- Addresses Gemini code review feedback from PR #1 (medium severity)

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example JSON format in README.md to use a generic timestamp placeholder pattern (YYYY-MM-DDTHH:MM:SSZ) instead of a fixed date value for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->