### PR TITLE
fix: restore symlink guards on SSH key chmod and simplify known_hosts logic

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -95,9 +95,12 @@ fi
 # ============================================
 # /home/cloudron/.ssh is a symlink to /app/data/.ssh (set up in Dockerfile)
 # Write directly to /app/data/.ssh — no copy needed
-# Set SSH key permissions if the files exist (as regular files, not symlinks)
-[[ -f /app/data/.ssh/id_ed25519 ]] && chmod 600 /app/data/.ssh/id_ed25519
-[[ -f /app/data/.ssh/id_ed25519.pub ]] && chmod 644 /app/data/.ssh/id_ed25519.pub
+# Set SSH key permissions if the files exist as regular files (not symlinks).
+# Guard: [[ -f ]] follows symlinks — a symlink to /etc/shadow would pass the -f
+# test and chmod would change permissions on the target. The explicit [[ ! -L ]]
+# check prevents this symlink attack vector.
+[[ ! -L /app/data/.ssh/id_ed25519 && -f /app/data/.ssh/id_ed25519 ]] && chmod 600 /app/data/.ssh/id_ed25519
+[[ ! -L /app/data/.ssh/id_ed25519.pub && -f /app/data/.ssh/id_ed25519.pub ]] && chmod 644 /app/data/.ssh/id_ed25519.pub
 
 # Pin GitHub SSH host key — replace any existing github.com entries to prevent
 # poisoned keys from persisting. Avoids MITM risk from ssh-keyscan.
@@ -108,11 +111,11 @@ PINNED_GITHUB_KEY="github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0Sd
 if [[ -L /app/data/.ssh/known_hosts ]]; then
 	rm -f /app/data/.ssh/known_hosts
 fi
-# Strip existing github.com entries (if file exists), then append the pinned key
+# Strip existing github.com entries (if file exists), then append the pinned key.
+# Initialize temp file first, then conditionally populate from existing known_hosts.
+: >/tmp/known_hosts.tmp
 if [[ -f /app/data/.ssh/known_hosts ]]; then
 	grep -vE '^github\.com[ ,]' /app/data/.ssh/known_hosts >/tmp/known_hosts.tmp || true
-else
-	: >/tmp/known_hosts.tmp
 fi
 printf '%s\n' "$PINNED_GITHUB_KEY" >>/tmp/known_hosts.tmp
 mv /tmp/known_hosts.tmp /app/data/.ssh/known_hosts


### PR DESCRIPTION
## Summary

Addresses high-severity quality-debt from PR #17 review feedback (Gemini Code Assist).

- **HIGH — Symlink attack on SSH key chmod**: Restored explicit `[[ ! -L ]]` guards before `[[ -f ]]` checks on SSH key permission operations. In bash, `[[ -f ]]` follows symlinks — a symlink at `/app/data/.ssh/id_ed25519` pointing to `/etc/shadow` would pass the `-f` test and `chmod` would change permissions on the target file. The `! -L` check prevents this attack vector.
- **MEDIUM — Simplify known_hosts logic**: Replaced the `if/else` block with initialize-first pattern — create the temp file unconditionally, then conditionally populate from existing `known_hosts`. Removes the `else` branch for cleaner control flow.

Both findings from: https://github.com/marcusquinn/aidevops-cloudron-app/pull/17

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced SSH key security with additional validation checks to prevent unauthorized access attempts.
  * Improved SSH configuration file handling for increased system reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->