### PR TITLE
fix: restore symlink guards on SSH key chmod to prevent symlink attacks

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -95,9 +95,13 @@ fi
 # ============================================
 # /home/cloudron/.ssh is a symlink to /app/data/.ssh (set up in Dockerfile)
 # Write directly to /app/data/.ssh — no copy needed
-# Set SSH key permissions if the files exist (as regular files, not symlinks)
-[[ -f /app/data/.ssh/id_ed25519 ]] && chmod 600 /app/data/.ssh/id_ed25519
-[[ -f /app/data/.ssh/id_ed25519.pub ]] && chmod 644 /app/data/.ssh/id_ed25519.pub
+# Set SSH key permissions if the files exist as regular files (not symlinks).
+# SECURITY: [[ -f ]] follows symlinks in bash — it returns true for a symlink
+# whose target is a regular file. An attacker could symlink id_ed25519 to
+# /etc/shadow, causing chmod to change permissions on the target file.
+# The [[ ! -L ]] guard prevents this by rejecting symlinks before chmod runs.
+[[ ! -L /app/data/.ssh/id_ed25519 && -f /app/data/.ssh/id_ed25519 ]] && chmod 600 /app/data/.ssh/id_ed25519
+[[ ! -L /app/data/.ssh/id_ed25519.pub && -f /app/data/.ssh/id_ed25519.pub ]] && chmod 644 /app/data/.ssh/id_ed25519.pub
 
 # Pin GitHub SSH host key — replace any existing github.com entries to prevent
 # poisoned keys from persisting. Avoids MITM risk from ssh-keyscan.
@@ -108,11 +112,11 @@ PINNED_GITHUB_KEY="github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0Sd
 if [[ -L /app/data/.ssh/known_hosts ]]; then
 	rm -f /app/data/.ssh/known_hosts
 fi
-# Strip existing github.com entries (if file exists), then append the pinned key
+# Strip existing github.com entries (if file exists), then append the pinned key.
+# Initialize temp file first, then conditionally populate — avoids else branch.
+: >/tmp/known_hosts.tmp
 if [[ -f /app/data/.ssh/known_hosts ]]; then
 	grep -vE '^github\.com[ ,]' /app/data/.ssh/known_hosts >/tmp/known_hosts.tmp || true
-else
-	: >/tmp/known_hosts.tmp
 fi
 printf '%s\n' "$PINNED_GITHUB_KEY" >>/tmp/known_hosts.tmp
 mv /tmp/known_hosts.tmp /app/data/.ssh/known_hosts


### PR DESCRIPTION
## Summary

Fixes high-severity symlink attack vulnerability in `start.sh` introduced by PR #17, based on Gemini Code Assist review feedback.

- **HIGH**: Restore `[[ ! -L ... ]]` symlink guards before `chmod` on SSH key files. PR #17 incorrectly claimed `[[ -f ]]` returns false for symlinks — in bash, `-f` follows symlinks and returns true if the target is a regular file. Without the guard, an attacker could symlink `id_ed25519` to `/etc/shadow` and `chmod 600` would change permissions on the target file (script runs as root).
- **MEDIUM**: Simplify `known_hosts` rebuild logic from if/else to initialize-then-populate pattern (clearer intent, same behaviour).

## Verification

- `shellcheck start.sh` passes clean
- No functional change to happy path — guards only reject symlinks, which should never exist at these paths in normal operation

Closes #20