### PR TITLE
GH#19: Use lowercase mm/ss for minutes/seconds in date format placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Add the worker to your local `~/.config/aidevops/remote-hosts.json`:
       "address": "https://worker.my.example.com",
       "transport": "http",
       "auth_token": "YOUR_AUTH_TOKEN",
-      "added": "YYYY-MM-DDTHH:MM:SSZ"
+      "added": "YYYY-MM-DDTHH:mm:ssZ"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes ambiguous date format placeholder in README.md where `MM` was used for both month and minutes
- Changed `YYYY-MM-DDTHH:MM:SSZ` to `YYYY-MM-DDTHH:mm:ssZ` following standard ISO 8601 conventions (`MM`=month, `mm`=minutes, `ss`=seconds)
- Addresses gemini-code-assist review feedback from PR #18

Closes #19