### PR TITLE
fix: address quality-debt from PR #25 review feedback

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    reviewers:
+      - "marcusquinn"
     open-pull-requests-limit: 5
   - package-ecosystem: "docker"
     directory: "/"
@@ -21,4 +23,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    reviewers:
+      - "marcusquinn"
     open-pull-requests-limit: 5

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Thumbs.db
 # Secrets and credentials
 .env
 .env.*
+!.env.example
 *.pem
 *.key
 credentials.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 |---------|-----------|
-| Latest  | Yes       |
+| `0.x`   | Yes       |
 
 ## Reporting a Vulnerability
 
@@ -12,7 +12,7 @@ If you discover a security vulnerability in this Cloudron app, please report it 
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email: **6428977+marcusquinn@users.noreply.github.com**
+Instead, please use the **Report a vulnerability** button on the repository's [Security tab](https://github.com/marcusquinn/aidevops-cloudron-app/security/advisories/new). This uses GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/managing-private-vulnerability-reporting-for-a-repository) feature, which provides a structured and secure workflow for handling disclosures.
 
 Include:
 


### PR DESCRIPTION
## Summary

Addresses all three quality-debt issues filed from PR #25 code review feedback:

- **SECURITY.md** (#28): Use specific version range (`0.x`) instead of generic "Latest" in supported versions table; replace personal email reporting with GitHub's Private Vulnerability Reporting feature
- **.gitignore** (#27): Add `!.env.example` exception so example environment files can be committed for contributor onboarding
- **dependabot.yml** (#26): Add `reviewers: ["marcusquinn"]` to both github-actions and docker ecosystem configs for prompt review of dependency PRs

Closes #26
Closes #27
Closes #28