### PR TITLE
chore: replace claude CLI with opencode across all files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,11 @@
 
 ## Project Overview
 
-Cloudron app that provides an always-on remote worker node for [aidevops](https://aidevops.sh). Runs headless Claude Code sessions inside a Docker container, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation and PR creation.
+Cloudron app that provides an always-on remote worker node for [aidevops](https://aidevops.sh). Runs headless OpenCode sessions inside a Docker container, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation and PR creation.
 
 ## Architecture
 
-Single-process Node.js server (`server.js`) handling health checks, a browser dashboard, and task dispatch. Workers are spawned as child processes running `claude -p` with `/full-loop` prompts. The container runs as the `cloudron` user (UID 1000) via `gosu`.
+Single-process Node.js server (`server.js`) handling health checks, a browser dashboard, and task dispatch. Workers are spawned as child processes running `opencode -p` with `/full-loop` prompts. The container runs as the `cloudron` user (UID 1000) via `gosu`.
 
 - `/app/code/` — read-only application code (Dockerfile, start.sh, server.js)
 - `/app/data/` — persistent storage (config, workspace, logs, SSH keys)

--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -2,7 +2,7 @@
   "id": "sh.aidevops.worker",
   "title": "AI DevOps Worker",
   "author": "Marcus Quinn <marcus@marcusquinn.com>",
-  "description": "Always-on remote worker node for AI DevOps. Runs headless OpenCode/Claude Code sessions, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation, PR creation, and multi-node orchestration.",
+  "description": "Always-on remote worker node for AI DevOps. Runs headless OpenCode sessions, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation, PR creation, and multi-node orchestration.",
   "tagline": "Remote AI worker node for autonomous code generation",
   "version": "0.1.0",
   "healthCheckPath": "/health",

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # ============================================
 # Node.js 20 LTS via NodeSource
-# cloudron/base includes Node 18 but Claude Code benefits from 20 LTS
+# cloudron/base includes Node 18; server.js and aidevops CLI need 20 LTS
 # ============================================
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -29,9 +29,13 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
-# Claude Code CLI + aidevops CLI
+# OpenCode CLI (from GitHub releases) + aidevops CLI (from npm)
 # ============================================
-RUN npm install -g @anthropic-ai/claude-code aidevops
+RUN curl -fsSL "https://github.com/anomalyco/opencode/releases/latest/download/opencode-linux-x64.tar.gz" \
+    | tar -xz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/opencode \
+    && opencode --version \
+    && npm install -g aidevops
 
 # ============================================
 # Writable home directories (Cloudron read-only /app/code workaround)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AI DevOps Worker — Cloudron App
 
-Always-on remote worker node for [aidevops](https://aidevops.sh). Runs headless Claude Code sessions inside a Cloudron-managed Docker container, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation and PR creation.
+Always-on remote worker node for [aidevops](https://aidevops.sh). Runs headless OpenCode sessions inside a Cloudron-managed Docker container, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation and PR creation.
 
 ## What This Does
 
 - Provides a **sandboxed, always-on compute node** for AI-powered code generation
 - Accepts task dispatches from your local aidevops supervisor or directly via HTTP API
-- Spawns headless Claude Code workers that clone repos, implement features, and create PRs
+- Spawns headless OpenCode workers that clone repos, implement features, and create PRs
 - Runs alongside your local machine — the supervisor can dispatch to both local and remote workers
 - Managed by Cloudron: automatic SSL, backups, updates, and monitoring
 
@@ -20,9 +20,9 @@ Your Machine (local)                    Cloudron Server (remote)
 |   (every 2 min)        |  POST        |     /dispatch                    |
 |                        |  /dispatch   |     /workers                     |
 | Local workers          |              |     /health                      |
-|   claude -p "..."      |              |                                  |
+|   opencode -p "..."    |              |                                  |
 |                        |              | Headless workers                 |
-| GitHub <--push/PR------+              |   claude -p "/full-loop ..."     |
+| GitHub <--push/PR------+              |   opencode -p "/full-loop ..."   |
 |        <--push/PR------+--------------+   git push -> GitHub             |
 +------------------------+              +----------------------------------+
 ```
@@ -262,7 +262,7 @@ Deploy to different Cloudron servers and add each to `remote-hosts.json`:
 
 ### Capacity Planning
 
-Workers are headless Claude Code CLI processes that make API calls — they do not run local model inference. Each worker is a lightweight Node.js process (~150-300 MB RAM including git repo clone). The practical limit is usually API rate limits, not RAM.
+Workers are headless OpenCode CLI processes that make API calls — they do not run local model inference. Each worker is a lightweight Node.js process (~150-300 MB RAM including git repo clone). The practical limit is usually API rate limits, not RAM.
 
 | Container Memory | Recommended `max_concurrent` | Notes |
 |------------------|------------------------------|-------|

--- a/server.js
+++ b/server.js
@@ -392,8 +392,8 @@ async function handleDispatch(req, res) {
     env.ANTHROPIC_MODEL = model;
   }
 
-  // Use claude CLI (installed globally) — spawn with array args, no shell
-  const workerProcess = spawn('claude', ['-p', prompt, '--allowedTools', '*'], {
+  // Use opencode CLI (installed globally) — spawn with array args, no shell
+  const workerProcess = spawn('opencode', ['-p', prompt, '--allowedTools', '*'], {
     cwd: repoDir,
     env,
     stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

- Replaces `@anthropic-ai/claude-code` (npm) with [OpenCode](https://github.com/anomalyco/opencode) (Go binary from GitHub releases) in the Dockerfile
- Updates `server.js` to spawn `opencode` instead of `claude` as the worker process
- Updates all documentation (README.md, AGENTS.md, CloudronManifest.json) to reference `opencode -p` consistently

All remaining `claude` references are model names (e.g., `claude-sonnet-4-6`) which are correct and unchanged.