### PR TITLE
GH#34: Add deterministic managed Cloudron lifecycle

### DIFF
--- a/.github/workflows/cloudron-package-release.yml
+++ b/.github/workflows/cloudron-package-release.yml
@@ -13,6 +13,6 @@ jobs:
   release:
     permissions:
       contents: write
-    uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@main
+    uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@22a6b4b29087ce2fcf3857596a40ff7b2c436482
     with:
-      aidevops_ref: main
+      aidevops_ref: 22a6b4b29087ce2fcf3857596a40ff7b2c436482

--- a/.github/workflows/cloudron-package-release.yml
+++ b/.github/workflows/cloudron-package-release.yml
@@ -1,0 +1,18 @@
+name: Cloudron Package Release
+
+# Managed by aidevops. Pushing a vX.Y.Z tag is the explicit publication trigger.
+# The reusable workflow validates the package before creating a GitHub release.
+# It does not publish images, Cloudron catalogs, or deployments.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@main
+    with:
+      aidevops_ref: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Managed tag-triggered Cloudron package release validation.
+
+### Changed
+
+- Pinned the final Cloudron base image, OpenCode `1.18.4`, and aidevops
+  `3.32.166` instead of resolving moving latest versions during builds.

--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -5,6 +5,7 @@
   "description": "Always-on remote worker node for AI DevOps. Runs headless OpenCode sessions, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation, PR creation, and multi-node orchestration.",
   "tagline": "Remote AI worker node for autonomous code generation",
   "version": "0.1.0",
+  "upstreamVersion": "3.32.166",
   "healthCheckPath": "/health",
   "httpPort": 3000,
   "manifestVersion": 2,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudron/base:5.0.0
+FROM cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c
 
 # ============================================
 # System dependencies
@@ -31,11 +31,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # ============================================
 # OpenCode CLI (from GitHub releases) + aidevops CLI (from npm)
 # ============================================
-RUN curl -fsSL "https://github.com/anomalyco/opencode/releases/latest/download/opencode-linux-x64.tar.gz" \
+ARG OPENCODE_VERSION=1.18.4
+ARG AIDEVOPS_VERSION=3.32.166
+
+RUN curl -fsSL "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
     | tar -xz -C /usr/local/bin \
     && chmod +x /usr/local/bin/opencode \
     && opencode --version \
-    && npm install -g aidevops
+    && npm install -g "aidevops@${AIDEVOPS_VERSION}"
 
 # ============================================
 # Writable home directories (Cloudron read-only /app/code workaround)

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -28,11 +28,12 @@ main() {
 	assert_contains Dockerfile 'ARG AIDEVOPS_VERSION=3.32.166' || return 1
 	assert_contains Dockerfile "releases/download/v\${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" || return 1
 	assert_contains Dockerfile "npm install -g \"aidevops@\${AIDEVOPS_VERSION}\"" || return 1
-	if grep -Fq '/releases/latest/' "${ROOT_DIR}/Dockerfile"; then
+	if grep -Eq '/releases/latest([/?#]|$)' "${ROOT_DIR}/Dockerfile"; then
 		fail "Dockerfile contains a moving latest release download" || return 1
 	fi
 	assert_contains .github/workflows/cloudron-package-release.yml "- 'v*'" || return 1
-	assert_contains .github/workflows/cloudron-package-release.yml 'uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@main' || return 1
+	assert_contains .github/workflows/cloudron-package-release.yml 'uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@22a6b4b29087ce2fcf3857596a40ff7b2c436482' || return 1
+	assert_contains .github/workflows/cloudron-package-release.yml 'aidevops_ref: 22a6b4b29087ce2fcf3857596a40ff7b2c436482' || return 1
 	bash -n "${ROOT_DIR}/start.sh"
 	shellcheck "${ROOT_DIR}/test/package-test.sh"
 	printf 'PASS: deterministic Cloudron package lifecycle contract\n'

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+ROOT_DIR="${TEST_DIR%/*}"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+assert_contains() {
+	local relative_path="$1"
+	local expected="$2"
+	grep -Fq -- "$expected" "${ROOT_DIR}/${relative_path}" || fail "${relative_path} is missing: ${expected}" || return 1
+	return 0
+}
+
+main() {
+	jq -e '.manifestVersion == 2 and .version == "0.1.0" and .upstreamVersion == "3.32.166"' \
+		"${ROOT_DIR}/CloudronManifest.json" >/dev/null || fail "Manifest version contract failed" || return 1
+	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1
+	assert_contains Dockerfile 'ARG OPENCODE_VERSION=1.18.4' || return 1
+	assert_contains Dockerfile 'ARG AIDEVOPS_VERSION=3.32.166' || return 1
+	assert_contains Dockerfile "releases/download/v\${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" || return 1
+	assert_contains Dockerfile "npm install -g \"aidevops@\${AIDEVOPS_VERSION}\"" || return 1
+	if grep -Fq '/releases/latest/' "${ROOT_DIR}/Dockerfile"; then
+		fail "Dockerfile contains a moving latest release download" || return 1
+	fi
+	assert_contains .github/workflows/cloudron-package-release.yml "- 'v*'" || return 1
+	assert_contains .github/workflows/cloudron-package-release.yml 'uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@main' || return 1
+	bash -n "${ROOT_DIR}/start.sh"
+	shellcheck "${ROOT_DIR}/test/package-test.sh"
+	printf 'PASS: deterministic Cloudron package lifecycle contract\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add the managed tag-triggered release caller and package test while pinning the final Cloudron base, OpenCode 1.18.4, and aidevops 3.32.166.

## Files Changed

.github/workflows/cloudron-package-release.yml, CHANGELOG.md, CloudronManifest.json, Dockerfile, test/package-test.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — The package test, ShellCheck, bash syntax, actionlint, git diff validation, and shared Cloudron compatibility audit pass.

Resolves #34


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.166 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 17h 22m and 8,309,699 tokens on this with the user in an interactive session.