### PR TITLE
t005: chore(release): publish AI DevOps Worker catalog 0.1.1

### DIFF
--- a/CloudronVersions.json
+++ b/CloudronVersions.json
@@ -38,8 +38,8 @@
                 "dockerImage": "marcusquinn/aidevops-cloudron-worker:0.1.1"
             },
             "creationDate": "Thu, 23 Jul 2026 23:21:17 GMT",
-            "ts": "Thu, 23 Jul 2026 23:21:17 GMT",
-            "publishState": "testing"
+            "ts": "Fri, 24 Jul 2026 00:48:34 GMT",
+            "publishState": "published"
         }
     }
 }

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -20,7 +20,7 @@ the catalog.
    `cloudron install --versions-url <PUBLIC_VERSIONS_URL> --location worker-test`.
    Also verify upgrade, restart, health checks, and backup/restore.
 6. Promote only the tested package with
-   `cloudron versions update --version <VERSION> --state published`, then
+   `cloudron versions update --version=<VERSION> --state=published`, then
    publish the updated catalog.
 7. Optionally sign in to [Cloudron Community Apps](https://ca.cloudron.io), add
    the same versions URL, and verify the imported icon, screenshot/hero,

--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t004 Prepare AI DevOps Worker community package publishing ref:GH#36
 
+- [ ] t005 Publish AI DevOps Worker 0.1.1 Cloudron catalog ref:GH#39
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -28,6 +28,8 @@ main() {
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
 	assert_contains CHANGELOG '[0.1.1]' || return 1
+	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
+	jq -e '.versions["0.1.1"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1
 	assert_contains Dockerfile 'ARG OPENCODE_VERSION=1.18.4' || return 1
 	assert_contains Dockerfile 'ARG AIDEVOPS_VERSION=3.32.176' || return 1


### PR DESCRIPTION
## Summary

Promote the tested 0.1.1 registry image to published in CloudronVersions.json and document the Cloudron CLI 7.0.4 equals-form option syntax.

## Files Changed

CloudronVersions.json, PUBLISHING.md, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: clean Cloudron install completed and the package health endpoint returned HTTP 200; package contract tests and Cloudron manifest validation passed after promotion.

Resolves #39


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.177 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 38m and 1,100,370 tokens on this with the user in an interactive session.