### PR TITLE
GH#42: Link AI DevOps Worker package repository

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[0.1.2]
+* Update the bundled aidevops CLI to 3.32.177.
+* Link the package repository and require Cloudron 10.0.0.
+
 [0.1.1]
 * Add deterministic release validation and community-package metadata.
 * Add reviewed icon and 3:1 hero assets.

--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -13,7 +13,7 @@
   "contactEmail": "marcus@marcusquinn.com",
   "icon": "file://logo.png",
   "documentationUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
-  "minBoxVersion": "9.1.0",
+  "minBoxVersion": "10.0.0",
   "memoryLimit": 2147483648,
   "addons": {
     "localstorage": {}
@@ -22,6 +22,7 @@
   "iconUrl": "https://raw.githubusercontent.com/marcusquinn/aidevops-cloudron-app/main/logo.png",
   "packagerName": "Marcus Quinn",
   "packagerUrl": "https://github.com/marcusquinn",
+  "packageUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
   "mediaLinks": [
     "https://aidevops.sh/og-image.png?v=3"
   ],

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -21,7 +21,7 @@ assert_contains() {
 }
 
 main() {
-	jq -e '.manifestVersion == 2 and .version == "0.1.2" and .upstreamVersion == "3.32.177" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl != "" and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
+	jq -e '.manifestVersion == 2 and .version == "0.1.2" and .upstreamVersion == "3.32.177" and .minBoxVersion == "10.0.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and .packageUrl == "https://github.com/marcusquinn/aidevops-cloudron-app" and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
 		"${ROOT_DIR}/CloudronManifest.json" >/dev/null || fail "Manifest version contract failed" || return 1
 	[[ -f "${ROOT_DIR}/CloudronVersions.json" ]] || fail "CloudronVersions.json is missing" || return 1
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1


### PR DESCRIPTION
## Summary

Add the package repository link, retain maintainer provenance, require Cloudron 10.0.0, and cover the metadata contract.

## Files Changed

CHANGELOG, CloudronManifest.json, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash test/package-test.sh; git diff --check

Resolves #42


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.179 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 40m and 1,493,661 tokens on this with the user in an interactive session.