### PR TITLE
GH#44: Publish AI DevOps Worker catalog 0.1.2

### DIFF
--- a/CloudronVersions.json
+++ b/CloudronVersions.json
@@ -40,6 +40,47 @@
             "creationDate": "Thu, 23 Jul 2026 23:21:17 GMT",
             "ts": "Fri, 24 Jul 2026 00:48:34 GMT",
             "publishState": "published"
+        },
+        "0.1.2": {
+            "manifest": {
+                "id": "sh.aidevops.worker",
+                "title": "AI DevOps Worker",
+                "author": "Marcus Quinn <marcus@marcusquinn.com>",
+                "description": "Always-on remote worker node for AI DevOps. Runs headless OpenCode sessions, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation, PR creation, and multi-node orchestration.",
+                "tagline": "Remote AI worker node for autonomous code generation",
+                "version": "0.1.2",
+                "upstreamVersion": "3.32.177",
+                "healthCheckPath": "/health",
+                "httpPort": 3000,
+                "manifestVersion": 2,
+                "website": "https://aidevops.sh",
+                "contactEmail": "marcus@marcusquinn.com",
+                "icon": "file://logo.png",
+                "documentationUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
+                "minBoxVersion": "10.0.0",
+                "memoryLimit": 2147483648,
+                "addons": {
+                    "localstorage": {}
+                },
+                "tcpPorts": {},
+                "iconUrl": "https://raw.githubusercontent.com/marcusquinn/aidevops-cloudron-app/main/logo.png",
+                "packagerName": "Marcus Quinn",
+                "packagerUrl": "https://github.com/marcusquinn",
+                "packageUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
+                "mediaLinks": [
+                    "https://aidevops.sh/og-image.png?v=3"
+                ],
+                "tags": [
+                    "ai",
+                    "automation",
+                    "developer-tools"
+                ],
+                "changelog": "* Update the bundled aidevops CLI to 3.32.177.\n* Link the package repository and require Cloudron 10.0.0.\n",
+                "dockerImage": "marcusquinn/aidevops-cloudron-worker:0.1.2"
+            },
+            "creationDate": "Fri, 24 Jul 2026 02:12:15 GMT",
+            "ts": "Fri, 24 Jul 2026 02:13:01 GMT",
+            "publishState": "published"
         }
     }
 }


### PR DESCRIPTION
## Summary

Append the image-backed 0.1.2 entry and publish it with Cloudron 10 package repository metadata while preserving 0.1.1.

## Files Changed

CloudronVersions.json

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: Cloudron CLI 8.2.6 validated the manifest, built and pushed the image, and added then promoted the exact catalog entry; package tests and catalog assertions passed; registry digest sha256:bc4db26484ff605e223953ffc58cb23b2005943f1e144dd4c1048488c3a6e4b6. The connected pre-10 test box correctly rejected unsupported packageUrl before app creation.

Resolves #44


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 59m and 1,579,270 tokens on this with the user in an interactive session.