### PR TITLE
t008: restore Cloudron 9.2 compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[0.1.3]
+* Restore installation and updates on Cloudron 9.1 and 9.2.
+* Temporarily omit packageUrl until Cloudron 10.0.0 is numerically available.
+
 [0.1.2]
 * Update the bundled aidevops CLI to 3.32.177.
 * Link the package repository and require Cloudron 10.0.0.

--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -4,7 +4,7 @@
   "author": "Marcus Quinn <marcus@marcusquinn.com>",
   "description": "Always-on remote worker node for AI DevOps. Runs headless OpenCode sessions, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation, PR creation, and multi-node orchestration.",
   "tagline": "Remote AI worker node for autonomous code generation",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "upstreamVersion": "3.32.177",
   "healthCheckPath": "/health",
   "httpPort": 3000,
@@ -13,7 +13,7 @@
   "contactEmail": "marcus@marcusquinn.com",
   "icon": "file://logo.png",
   "documentationUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
-  "minBoxVersion": "10.0.0",
+  "minBoxVersion": "9.1.0",
   "memoryLimit": 2147483648,
   "addons": {
     "localstorage": {}
@@ -22,7 +22,6 @@
   "iconUrl": "https://raw.githubusercontent.com/marcusquinn/aidevops-cloudron-app/main/logo.png",
   "packagerName": "Marcus Quinn",
   "packagerUrl": "https://github.com/marcusquinn",
-  "packageUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
   "mediaLinks": [
     "https://aidevops.sh/og-image.png?v=3"
   ],

--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t005 Publish AI DevOps Worker 0.1.1 Cloudron catalog ref:GH#39
 
+- [ ] t008 Restore Cloudron 9.2 compatibility ref:GH#46
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -21,15 +21,15 @@ assert_contains() {
 }
 
 main() {
-	jq -e '.manifestVersion == 2 and .version == "0.1.2" and .upstreamVersion == "3.32.177" and .minBoxVersion == "10.0.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and .packageUrl == "https://github.com/marcusquinn/aidevops-cloudron-app" and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
+	jq -e '.manifestVersion == 2 and .version == "0.1.3" and .upstreamVersion == "3.32.177" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and (has("packageUrl") | not) and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
 		"${ROOT_DIR}/CloudronManifest.json" >/dev/null || fail "Manifest version contract failed" || return 1
 	[[ -f "${ROOT_DIR}/CloudronVersions.json" ]] || fail "CloudronVersions.json is missing" || return 1
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
-	assert_contains CHANGELOG.md '[0.1.2]' || return 1
+	assert_contains CHANGELOG '[0.1.3]' || return 1
 	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
-	jq -e '.versions["0.1.1"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
+	jq -e '.versions["0.1.2"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1
 	assert_contains Dockerfile 'ARG OPENCODE_VERSION=1.18.4' || return 1
 	assert_contains Dockerfile 'ARG AIDEVOPS_VERSION=3.32.177' || return 1


### PR DESCRIPTION
## Summary

Bump AI DevOps Worker to 0.1.3, remove the Cloudron-10-only packageUrl field, restore minBoxVersion 9.1.0, and add a regression assertion.

## Files Changed

CHANGELOG, CloudronManifest.json, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — jq validation and test/package-test.sh pass; Cloudron CLI schema validation will run during catalog generation.

Resolves #46


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4h 48m and 1,919,885 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and updating on Cloudron 9.1 and 9.2.
* **Bug Fixes**
  * Restored compatibility with supported Cloudron versions.
  * Improved package publishing behavior by omitting the package URL until Cloudron 10.0.0 is available.
* **Documentation**
  * Added release notes for version 0.1.3, documenting compatibility and publishing changes.
* **Chores**
  * Updated the application release to version 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->