### PR TITLE
t009: publish AI DevOps Worker catalog 0.1.3

### DIFF
--- a/CloudronVersions.json
+++ b/CloudronVersions.json
@@ -81,6 +81,46 @@
             "creationDate": "Fri, 24 Jul 2026 02:12:15 GMT",
             "ts": "Fri, 24 Jul 2026 02:13:01 GMT",
             "publishState": "published"
+        },
+        "0.1.3": {
+            "manifest": {
+                "id": "sh.aidevops.worker",
+                "title": "AI DevOps Worker",
+                "author": "Marcus Quinn <marcus@marcusquinn.com>",
+                "description": "Always-on remote worker node for AI DevOps. Runs headless OpenCode sessions, accepts task dispatches via HTTP API, and integrates with the aidevops supervisor pulse for autonomous code generation, PR creation, and multi-node orchestration.",
+                "tagline": "Remote AI worker node for autonomous code generation",
+                "version": "0.1.3",
+                "upstreamVersion": "3.32.177",
+                "healthCheckPath": "/health",
+                "httpPort": 3000,
+                "manifestVersion": 2,
+                "website": "https://aidevops.sh",
+                "contactEmail": "marcus@marcusquinn.com",
+                "icon": "file://logo.png",
+                "documentationUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
+                "minBoxVersion": "9.1.0",
+                "memoryLimit": 2147483648,
+                "addons": {
+                    "localstorage": {}
+                },
+                "tcpPorts": {},
+                "iconUrl": "https://raw.githubusercontent.com/marcusquinn/aidevops-cloudron-app/main/logo.png",
+                "packagerName": "Marcus Quinn",
+                "packagerUrl": "https://github.com/marcusquinn",
+                "mediaLinks": [
+                    "https://aidevops.sh/og-image.png?v=3"
+                ],
+                "tags": [
+                    "ai",
+                    "automation",
+                    "developer-tools"
+                ],
+                "changelog": "* Restore installation and updates on Cloudron 9.1 and 9.2.\n* Temporarily omit packageUrl until Cloudron 10.0.0 is numerically available.\n",
+                "dockerImage": "marcusquinn/aidevops-cloudron-worker:0.1.3"
+            },
+            "creationDate": "Fri, 24 Jul 2026 03:20:01 GMT",
+            "ts": "Fri, 24 Jul 2026 03:20:49 GMT",
+            "publishState": "published"
         }
     }
 }

--- a/TODO.md
+++ b/TODO.md
@@ -63,6 +63,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t008 Restore Cloudron 9.2 compatibility ref:GH#46
 
+- [ ] t009 Publish AI DevOps Worker 0.1.3 Cloudron catalog ref:GH#48
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:


### PR DESCRIPTION
## Summary

Publish the Cloudron CLI-generated AI DevOps Worker 0.1.3 catalog entry using the pushed amd64 registry image.

## Files Changed

CloudronVersions.json, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Registry runtime verified: tags 0.1.2 and 0.1.3 resolve to the identical sha256:bc4db26484ff605e223953ffc58cb23b2005943f1e144dd4c1048488c3a6e4b6 runtime image; package tests and exact catalog assertions pass.

Resolves #48


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 5h 7m and 2,003,485 tokens on this with the user in an interactive session.