### PR TITLE
t010: validate Worker 0.1.3 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-24
+
+### Fixed
+
+- Restored Cloudron 9.1 and 9.2 installation and update compatibility by
+  temporarily omitting `packageUrl` until Cloudron 10.0.0 is numerically
+  available.
+
 ## [0.1.2] - 2026-07-24
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t009 Publish AI DevOps Worker 0.1.3 Cloudron catalog ref:GH#48
 
+- [ ] t010 Fix Worker 0.1.3 release changelog validation ref:GH#50
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -28,6 +28,7 @@ main() {
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
 	assert_contains CHANGELOG '[0.1.3]' || return 1
+	assert_contains CHANGELOG.md '[0.1.3]' || return 1
 	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
 	jq -e '.versions["0.1.2"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1


### PR DESCRIPTION
## Summary

Add the missing Keep a Changelog section for Worker 0.1.3 and require both release changelog formats in package tests.

## Files Changed

CHANGELOG.md, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — test/package-test.sh, ShellCheck, git diff --check, and cloudron-package-helper.sh check-release v0.1.3 pass.

Resolves #50


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 5h 16m and 2,070,276 tokens on this with the user in an interactive session.