### PR TITLE
GH#60: pin changelog version assertions

### DIFF
--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -27,8 +27,8 @@ main() {
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
-	assert_contains CHANGELOG '[0.1.7]' || return 1
-	assert_contains CHANGELOG.md '[0.1.7]' || return 1
+	assert_contains CHANGELOG '* Update the bundled aidevops CLI to 3.32.189.' || return 1
+	assert_contains CHANGELOG.md "- Updated and pinned the bundled aidevops CLI to \`3.32.189\`." || return 1
 	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
 	jq -e '.versions["0.1.3"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1


### PR DESCRIPTION
## Summary

Replace broad release-heading checks with exact aidevops 3.32.189 changelog entry assertions in both changelog formats.

## Files Changed

test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash test/package-test.sh; git diff --check origin/main...HEAD

Resolves #60


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.189 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 5m and 63,510 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated release validation checks to verify the bundled CLI’s current changelog entries.
  * Improved confidence that packaged releases include accurate version-specific release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->