### PR TITLE
GH#63: pin linked issue workflow revision

### DIFF
--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -22,4 +22,4 @@ on:
 
 jobs:
   check:
-    uses: marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml@main
+    uses: marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml@2e256f481c378ca338d70f4b73493d65b8cc396d


### PR DESCRIPTION
## Summary

Pinned the linked-issue reusable workflow to the reviewed immutable aidevops commit 2e256f481c378ca338d70f4b73493d65b8cc396d, preventing pull_request_target policy drift from mutable main updates.

## Files Changed

.github/workflows/linked-issue-check.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — actionlint .github/workflows/linked-issue-check.yml; git diff --check; GitHub Contents API verified the reusable workflow exists at the pinned revision

Resolves #63


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.195 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7m and 66,837 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated linked-issue checks to use a fixed workflow version.
  - This provides more consistent and predictable validation results across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->