### PR TITLE
t011: Restore Cloudron 9.2 catalog compatibility

### DIFF
--- a/CloudronVersions.json
+++ b/CloudronVersions.json
@@ -66,7 +66,6 @@
                 "iconUrl": "https://raw.githubusercontent.com/marcusquinn/aidevops-cloudron-app/main/logo.png",
                 "packagerName": "Marcus Quinn",
                 "packagerUrl": "https://github.com/marcusquinn",
-                "packageUrl": "https://github.com/marcusquinn/aidevops-cloudron-app",
                 "mediaLinks": [
                     "https://aidevops.sh/og-image.png?v=3"
                 ],

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -30,6 +30,14 @@ Published entries are append-only. For a critical bad release, run
 `cloudron versions revoke`, bump the package version, rebuild, and add a new
 entry. Do not mutate the manifest or image of a published version.
 
+Cloudron validates the complete catalog before selecting a compatible version.
+Every historical manifest must therefore remain parseable by the oldest
+supported Cloudron release. Do not add fields introduced by a newer Cloudron
+to any catalog entry while older releases remain supported. The append-only
+rule has one narrow exception: incompatible catalog metadata may be corrected
+only when it otherwise makes the complete catalog unusable. Published images
+and runtime package contents remain immutable.
+
 ## Visual assets
 
 - `logo.png`: canonical 256×256 package icon.

--- a/TODO.md
+++ b/TODO.md
@@ -67,6 +67,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t010 Fix Worker 0.1.3 release changelog validation ref:GH#50
 
+- [ ] t011 Repair historical catalog entry for Cloudron 9.2 #bug ref:GH#66
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -27,6 +27,7 @@ main() {
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
+	jq -e '[.versions[].manifest | has("packageUrl")] | all(. == false)' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Historical catalog entries must remain parseable by Cloudron 9.1 and 9.2" || return 1
 	assert_contains CHANGELOG '* Update the bundled aidevops CLI to 3.32.189.' || return 1
 	assert_contains CHANGELOG.md "- Updated and pinned the bundled aidevops CLI to \`3.32.189\`." || return 1
 	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -27,7 +27,7 @@ main() {
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
-	jq -e '[.versions[].manifest | has("packageUrl")] | all(. == false)' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Historical catalog entries must remain parseable by Cloudron 9.1 and 9.2" || return 1
+	jq -e '[.versions[].manifest | has("packageUrl")] | all(. == false)' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Historical catalog entries must not use Cloudron-10-only packageUrl" || return 1
 	assert_contains CHANGELOG '* Update the bundled aidevops CLI to 3.32.189.' || return 1
 	assert_contains CHANGELOG.md "- Updated and pinned the bundled aidevops CLI to \`3.32.189\`." || return 1
 	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1


### PR DESCRIPTION
## Summary

Remove the Cloudron-10-only packageUrl field from historical version 0.1.2, add an all-history compatibility assertion, and document the narrow metadata-repair exception without changing images or package state.

## Files Changed

CloudronVersions.json, PUBLISHING.md, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — bash test/package-test.sh; cloudron versions verify; @cloudron/manifest-format 6.2.0 parseVersions accepted CloudronVersions.json.

Resolves #66


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 33m and 483,116 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for maintaining compatibility with older Cloudron releases and preserving catalog usability.
* **Bug Fixes**
  * Corrected a historical catalog entry by removing an unsupported metadata field.
* **Tests**
  * Added validation to ensure historical catalog entries remain compatible and free of unsupported fields.
* **Chores**
  * Added a backlog item to track repair of the historical catalog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->