### PR TITLE
t013: Add keyless provenance for Cloudron catalogs

### DIFF
--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -147,7 +147,9 @@ jobs:
     if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'true'
     runs-on: ubuntu-24.04
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Check out the verified revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -187,6 +189,22 @@ jobs:
           EXPECTED_IMAGE_REF: ${{ needs.build.outputs.image_ref }}
           EXPECTED_VERSION: ${{ needs.preflight.outputs.version }}
         run: bash scripts/publish-cloudron-catalog.sh CloudronVersions.json "${EXPECTED_IMAGE_REF}" "${EXPECTED_VERSION}"
+
+      - name: Attest generated Cloudron catalog
+        id: attest-catalog
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: CloudronVersions.json
+
+      - name: Verify generated Cloudron catalog provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify CloudronVersions.json \
+            --bundle "${{ steps.attest-catalog.outputs.bundle-path }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/cloudron-catalog-publish.yml" \
+            --source-ref refs/heads/main
 
       - name: Commit generated catalog
         env:
@@ -246,7 +264,9 @@ jobs:
     if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'false'
     runs-on: ubuntu-24.04
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Check out published source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -266,6 +286,22 @@ jobs:
               jq -r --arg version "${RELEASE_VERSION}" '.versions[$version].manifest.dockerImage'
           )"
           test "${tagged_image_ref}" = "${IMMUTABLE_REF}"
+
+      - name: Attest existing Cloudron catalog
+        id: attest-catalog
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: CloudronVersions.json
+
+      - name: Verify existing Cloudron catalog provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify CloudronVersions.json \
+            --bundle "${{ steps.attest-catalog.outputs.bundle-path }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/cloudron-catalog-publish.yml" \
+            --source-ref refs/heads/main
 
       - name: Reconcile GitHub release
         env:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -21,12 +21,15 @@ tag or digest into the catalog.
 4. The workflow runs `scripts/publish-cloudron-catalog.sh`, which adds the new
    manifest version in testing state, verifies the generated entry and digest,
    promotes that exact version to published, and verifies the final catalog.
-5. The workflow commits only the generated `CloudronVersions.json`, atomically
-   pushes that commit with the matching `v<VERSION>` tag, attests the image
-   digest, and creates the GitHub release, but only after an anonymous pull
-   probe resolves that exact digest. Existing published versions reverify the
-   anonymous image and tagged catalog digest, then reconcile a missing GitHub
-   release. Mutable, unpublished, or conflicting entries fail closed.
+5. The workflow creates Sigstore keyless provenance for both the immutable image
+   digest and the exact generated `CloudronVersions.json`. It verifies the
+   catalog attestation bundle against this repository, the publishing workflow,
+   and the `main` source ref before committing only the generated catalog,
+   atomically pushing that commit with the matching `v<VERSION>` tag, and
+   creating the GitHub release. Existing published versions reverify the
+   anonymous image and tagged catalog digest, attest and verify the current
+   catalog without a version bump, then reconcile a missing GitHub release.
+   Mutable, unpublished, or conflicting entries fail closed.
 6. For release qualification, test a clean install with
    `cloudron install --versions-url <PUBLIC_VERSIONS_URL> --location worker-test`.
    Also verify upgrade, restart, health checks, and backup/restore.
@@ -36,6 +39,12 @@ tag or digest into the catalog.
 
 The workflow is the only supported catalog writer. A merge that does not bump
 `CloudronManifest.json` is a verified no-op and does not create another release.
+
+GitHub Actions OIDC supplies the short-lived identity used for the image and
+catalog attestations, so publication requires no stored signing key. These
+attestations provide independently verifiable provenance, but Cloudron does not
+currently enforce Sigstore provenance when it imports a catalog or installs an
+image.
 
 ## Release credential
 

--- a/TODO.md
+++ b/TODO.md
@@ -71,6 +71,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t012 Automate Cloudron releases after package updates merge #feat #priority:high ref:GH#68
 
+- [ ] t013 Add keyless provenance for Cloudron catalogs ref:GH#72
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -64,6 +64,11 @@ main() {
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Require trusted publication source' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'EXPECTED_REF: refs/heads/main' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'attestations: write' || return 1
+	[[ "$(grep -Fc 'subject-path: CloudronVersions.json' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml")" -eq 2 ]] || fail "Both catalog paths must attest CloudronVersions.json" || return 1
+	[[ "$(grep -Fc 'gh attestation verify CloudronVersions.json' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml")" -eq 2 ]] || fail "Both catalog paths must verify CloudronVersions.json provenance" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "--bundle \"\${{ steps.attest-catalog.outputs.bundle-path }}\"" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "--signer-workflow \"\${GITHUB_REPOSITORY}/.github/workflows/cloudron-catalog-publish.yml\"" || return 1
+	[[ "$(grep -Fc -- '--source-ref refs/heads/main' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml")" -eq 2 ]] || fail "Both catalog verifications must require the main source ref" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'CLOUDRON_CLI_INTEGRITY: sha512-LHd+4u6pJxDtHX1JuVuWqrUuTbkDu+iH4jjNWW6JgB4+iDLusp08rpt6gifTFPbQjbCZHhnD8LbAGzM1NzDCXw==' || return 1
 	assert_precedes .github/workflows/cloudron-catalog-publish.yml 'registry_integrity=' 'npm install --global --ignore-scripts' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'scripts/publish-cloudron-catalog.sh' || return 1


### PR DESCRIPTION
## Summary

Attest generated and existing Cloudron catalog bytes with GitHub OIDC/Sigstore and verify the exact bundle before publication.

## Files Changed

.github/workflows/cloudron-catalog-publish.yml, PUBLISHING.md, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Package publisher tests and actionlint pass locally; post-merge catalog workflow and public attestation verification will provide runtime evidence.

Resolves #72


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.206 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 32m and 387,503 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated provenance attestation and verification for published Cloudron catalog data and immutable image digests.
  * Validates the signing workflow, repository, and main branch source reference before publication continues.
  * Existing releases can now be re-attested during reconciliation.

* **Documentation**
  * Updated release documentation with provenance behavior, validation rules, and failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->