### PR TITLE
GH#76: Clarify catalog no-op release reconciliation

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -38,7 +38,9 @@ tag or digest into the catalog.
    description, changelog, and install URL.
 
 The workflow is the only supported catalog writer. A merge that does not bump
-`CloudronManifest.json` is a verified no-op and does not create another release.
+`CloudronManifest.json` is a verified catalog no-op: the catalog remains
+unchanged, although the workflow may reconcile a missing GitHub release for the
+existing published version.
 
 GitHub Actions OIDC supplies the short-lived identity used for the image and
 catalog attestations, so publication requires no stored signing key. These


### PR DESCRIPTION
## Summary

Clarify that no-version-bump runs leave the catalog unchanged while still reconciling a missing GitHub release.

## Files Changed

PUBLISHING.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — markdownlint PUBLISHING.md

Resolves #76


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4m and 53,665 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified publishing behavior for verified no-op manifest updates.
  * Documented that missing GitHub releases can be reconciled without changing the existing catalog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->