### PR TITLE
GH#84: test: assert changelog release headings

### DIFF
--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -40,7 +40,9 @@ main() {
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
 	jq -e '[.versions[].manifest | has("packageUrl")] | all(. == false)' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Historical catalog entries must not use Cloudron-10-only packageUrl" || return 1
+	assert_contains CHANGELOG '[0.1.12]' || return 1
 	assert_contains CHANGELOG '* Update the bundled aidevops CLI to 3.32.220.' || return 1
+	assert_contains CHANGELOG.md '## [0.1.12]' || return 1
 	assert_contains CHANGELOG.md "- Updated and pinned the bundled aidevops CLI to \`3.32.220\`." || return 1
 	assert_contains PUBLISHING.md 'is standing authorization for the managed publication' || return 1
 	assert_contains PUBLISHING.md 'ghcr.io/marcusquinn/aidevops-cloudron-worker' || return 1


### PR DESCRIPTION
## Summary

Added release-heading assertions for both changelogs so the 3.32.220 entries are explicitly tied to package 0.1.12.

## Files Changed

test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck test/package-test.sh; bash test/package-test.sh

Resolves #84


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.234 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 5m and 58,305 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated package validation to verify the `0.1.12` release heading is present in the changelog.
  * Retained coverage for the changelog’s release heading and CLI update entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->