### PR TITLE
GH#115: Synchronize Cloudron package contract

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+[0.1.15]
+* Update the bundled aidevops CLI to 3.32.291.
+
+[0.1.14]
+* Update the bundled aidevops CLI to 3.32.290.
+
 [0.1.13]
 * Update the bundled aidevops CLI to 3.32.239.
 

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -33,17 +33,17 @@ assert_precedes() {
 }
 
 main() {
-	jq -e '.manifestVersion == 2 and .version == "0.1.13" and .upstreamVersion == "3.32.239" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and (has("packageUrl") | not) and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
+	jq -e '.manifestVersion == 2 and .version == "0.1.15" and .upstreamVersion == "3.32.291" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and (has("packageUrl") | not) and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
 		"${ROOT_DIR}/CloudronManifest.json" >/dev/null || fail "Manifest version contract failed" || return 1
 	[[ -f "${ROOT_DIR}/CloudronVersions.json" ]] || fail "CloudronVersions.json is missing" || return 1
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
 	jq -e '[.versions[].manifest | has("packageUrl")] | all(. == false)' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Historical catalog entries must not use Cloudron-10-only packageUrl" || return 1
-	assert_contains CHANGELOG '[0.1.13]' || return 1
-	assert_contains CHANGELOG '* Update the bundled aidevops CLI to 3.32.239.' || return 1
-	assert_contains CHANGELOG.md '## [0.1.13]' || return 1
-	assert_contains CHANGELOG.md "- Updated and pinned the bundled aidevops CLI to \`3.32.239\`." || return 1
+	assert_contains CHANGELOG '[0.1.15]' || return 1
+	assert_contains CHANGELOG '* Update the bundled aidevops CLI to 3.32.291.' || return 1
+	assert_contains CHANGELOG.md '## [0.1.15]' || return 1
+	assert_contains CHANGELOG.md "- Updated and pinned the bundled aidevops CLI to \`3.32.291\`." || return 1
 	assert_contains PUBLISHING.md 'is standing authorization for the managed publication' || return 1
 	assert_contains PUBLISHING.md 'ghcr.io/marcusquinn/aidevops-cloudron-worker' || return 1
 	jq -e '.versions["0.1.3"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
@@ -51,7 +51,7 @@ main() {
 	assert_contains Dockerfile 'LABEL org.opencontainers.image.source="https://github.com/marcusquinn/aidevops-cloudron-app"' || return 1
 	assert_contains Dockerfile '    ripgrep' || return 1
 	assert_contains Dockerfile 'ARG OPENCODE_VERSION=1.18.4' || return 1
-	assert_contains Dockerfile 'ARG AIDEVOPS_VERSION=3.32.239' || return 1
+	assert_contains Dockerfile 'ARG AIDEVOPS_VERSION=3.32.291' || return 1
 	assert_contains Dockerfile "releases/download/v\${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" || return 1
 	assert_contains Dockerfile "npm install -g \"aidevops@\${AIDEVOPS_VERSION}\"" || return 1
 	if grep -Eq '/releases/latest([/?#]|$)' "${ROOT_DIR}/Dockerfile"; then


### PR DESCRIPTION
Resolves #115

## Summary

- synchronize the plain Cloudron changelog with released package versions 0.1.14 and 0.1.15
- align package contract assertions with the current package 0.1.15 and bundled aidevops 3.32.291

## Verification

- `bash test/package-test.sh`
- `cloudron-package-helper.sh check-release v0.1.15`

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.291 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra
