### PR TITLE
GH#95: fix: document Cloudron base image update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 
 [0.1.13]
 * Update the bundled aidevops CLI to 3.32.239.
+* Update the Cloudron base image to 5.1.0.
 
 [0.1.12]
 * Update the bundled aidevops CLI to 3.32.220.


### PR DESCRIPTION
## Summary

- Document the Cloudron 5.1.0 base-image update in the 0.1.13 package changelog.
- Keep Cloudron package release notes aligned with `CHANGELOG.md`.

## Testing

- `bash test/package-test.sh`

Resolves #95

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.293 plugin for [OpenCode](https://opencode.ai) v1.18.23 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Cloudron base image to version 5.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->